### PR TITLE
fix: Plain.content's type is Inlines

### DIFF
--- a/src/pandoc-types-annotations.lua
+++ b/src/pandoc-types-annotations.lua
@@ -62,7 +62,7 @@ https://raw.githubusercontent.com/massifrg/pandoc-luals-annotations/main/src/pan
 ---@alias InlineWithAttr Span|Code|Link|Image
 
 ---@class Plain: Block A Pandoc `Plain`.
----@field content Blocks
+---@field content Inlines
 
 ---@class Para: Block A Pandoc `Para`.
 ---@field content Inlines


### PR DESCRIPTION
According to the [reference](https://pandoc.org/lua-filters.html#pandoc.Plain), `Plain.content` has type `Inlines`, not `Blocks`. This is also confirmed by examples in the reference itself.